### PR TITLE
Fix SASS version for todo-front (Kub. Exercises)

### DIFF
--- a/02-orquestacion/exercises/02-distributed/todo-front/package.json
+++ b/02-orquestacion/exercises/02-distributed/todo-front/package.json
@@ -35,7 +35,7 @@
     "regenerator": "^0.14.7",
     "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",
-    "sass": "^1.51.0",
+    "sass": "1.58.3",
     "sass-loader": "^12.6.0",
     "typescript": "^4.6.4",
     "webpack": "^5.72.1",


### PR DESCRIPTION
Latest SASS version (1.59.2) brings an error which can be checked here:
- https://github.com/sass/dart-sass/issues/1912

In order to avoid this issue, I've set SASS version to 1.58.3 (latest stable version)