### PR TITLE
Fix typos at "entornos linux" `.md` files

### DIFF
--- a/00-fundamentos-linux/01-entornos-linux/01-gestion-de-paquetes.md
+++ b/00-fundamentos-linux/01-entornos-linux/01-gestion-de-paquetes.md
@@ -17,7 +17,7 @@ Ejemplos de gestores de paquetes:
 - `pacman` - utilizados en sistemas basados en Arch (`yay` y derivados para el repositorio AUR).
 - `rpm`, `yum` y su sucesora `dnf` - utilizados en sistemas basados en Red Hat Enterprise Linux.
 - `nix` - gestor de paquetes sin distribución específica
-- `portage` - utilizados en sistemas basadaos en Gentoo
+- `portage` - utilizados en sistemas basados en Gentoo
 
 Las distribuciones que utilizan gestores de paquetes obtienen sus paquetes de **repositorios**. Los repositorios son servidores públicos cuyo objetivo es almacenar paquetes a disposición de los usuarios. Existen repositorios oficiales y no oficiales. Los paquetes que provienen de repositorios oficiales son mantenidos por las entidades que crearon la distribución. Los repositorios no oficiales son mantenidos por la comunidad para aportar paquetes que los creadores de la distribución no admiten como paquetes core por diversos motivos (por ejemplo, filosofía OpenSource).
 

--- a/00-fundamentos-linux/01-entornos-linux/02-gestion-de-entorno.md
+++ b/00-fundamentos-linux/01-entornos-linux/02-gestion-de-entorno.md
@@ -188,9 +188,9 @@ El comando `ps` muestra un reporte de los procesos actuales del sistema.
 Tiene una gran variedad de opciones. Varios ejemplos de combinaciones de flags:
 
 - `ps aux` - Muestra información detallada de todos los procesos
-- `ps -fu &lt;username&gt; - Lista los procesos de varios usuarios separados por coma.
-- `ps --forest -fC &lt;command&gt; - Lista los procesos relacionados con el comando en árbol.
-- `ps -p &lt;pid&gt; - Lista los procesos en base al PID o PIDs separados por coma
+- `ps -fu <username>` - Lista los procesos de varios usuarios separados por coma.
+- `ps --forest -fC <command>` - Lista los procesos relacionados con el comando en árbol.
+- `ps -p <pid>` - Lista los procesos en base al PID o PIDs separados por coma
 
 ```
 $ ps -fu vagrant
@@ -217,7 +217,7 @@ Para enviar señales a un proceso podemos escribirlo de varias formas:
 - `-<ID-SEÑAL>`: `kill -15 229`
 - `-SIG<SEÑAL>`: `kill -SIGTERM 229`
 - `<SEÑAL>`: `kill SIGTERM 229`
-- `-s <SEÑAL>`: kill -s SIGTERM 229
+- `-s <SEÑAL>`: `kill -s SIGTERM 229`
 
 Para ver el objetivo de cada señal podemos verlos con `man 7 signal`. También un programa puede actuar de una forma u otra dependiendo de la señal que enviemos, por ejemplo, la señal `SIGHUP` en un proceso Nginx recarga su configuración o `SIGQUIT` espera a que todas las conexiones establecidas sean cerradas antes de abortar el proceso, a diferencia de `SIGTERM` que corta las conexiones y sale directamente.
 


### PR DESCRIPTION
Revisando los materiales de la sesión 1 del módulo de Linux del bootcamp devops he encontrado algunas erratas de fácil solución. Creo esta PR para corregirlas. Si en el futuro encuentro más, iré creando PRs desde mi _fork_. 